### PR TITLE
Move EOF to start of the line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You will need `curl`, and `jq`:
               "Ok"
               '((content-type . "text/plain"))
               "Héllo world!"))))
-;; EOF
+EOF
 ```
 
 To deploy use the following:


### PR DESCRIPTION
The heredoc marker is processed by the shell (it does not end up in the file, so commenting it out is not needed, not even for the  purposes of pacifying syntax highlighting) and must be at the start of line. Copy-pasting the example into a shell does not  terminate it, so I need to type EOF again (and the `;; EOF` comment ends up in the file, which is not correct either).